### PR TITLE
Mark file type as CSV when attaching file to email

### DIFF
--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -11,7 +11,8 @@ function sendMail({ email, csv }) {
       personalisation: {
         subject,
         url: process.env.SERVICE_START,
-        link: client.prepareUpload(Buffer.from(csv))
+        // second argument to `prepareUpload` marks file type as CSV
+        link: client.prepareUpload(Buffer.from(csv), true)
       }
     });
   });


### PR DESCRIPTION
By default it is interpreted as plain text, but `prepareUpload` has an optional second parameter which sets the type to CSV.

See https://docs.notifications.service.gov.uk/node.html#csv-files