### PR TITLE
Use custom link renderer in Markdown

### DIFF
--- a/components/CheckboxGroup/index.js
+++ b/components/CheckboxGroup/index.js
@@ -1,4 +1,4 @@
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../Markdown';
 import classnames from 'classnames';
 import Field from '../Field';
 import Snippet from '../Snippet';
@@ -21,7 +21,7 @@ export default function CheckboxGroup({ name, label, hint, options, value, onFie
           <h1 className="nhsuk-fieldset__heading">{ label }</h1>
         </legend>
         {
-          hint && <div className="nhsuk-hint" id={`${name}-hint`}><ReactMarkdown>{ hint }</ReactMarkdown></div>
+          hint && <div className="nhsuk-hint" id={`${name}-hint`}><Markdown>{ hint }</Markdown></div>
         }
         <div className="nhsuk-checkboxes">
           {

--- a/components/Markdown/index.js
+++ b/components/Markdown/index.js
@@ -1,0 +1,19 @@
+import ReactMarkdown from 'react-markdown';
+
+function ExternalLink({ href='', children }) {
+  if (href.match(/^http/)) {
+    return <a href={href} target="_blank" rel="noreferrer">{ children } (opens in a new tab)</a>
+  }
+  return <a href={href}>{ children }</a>
+}
+
+export default function Markdown({ components = {}, children, ...props }) {
+
+  return <ReactMarkdown
+    {...props}
+    components = {{ ...components, a: ExternalLink }}
+    >
+      { children }
+    </ReactMarkdown>
+
+}

--- a/components/RadioGroup/index.js
+++ b/components/RadioGroup/index.js
@@ -1,4 +1,4 @@
-import ReactMarkdown from 'react-markdown';
+import Markdown from '../Markdown';
 
 export default function RadioGroup({ name, label, hint, options, value, onFieldChange }) {
   function onChange(e) {
@@ -13,7 +13,7 @@ export default function RadioGroup({ name, label, hint, options, value, onFieldC
           <h1 className="nhsuk-fieldset__heading">{label}</h1>
         </legend>
         {
-          hint && <div className="nhsuk-hint" id={`${name}-hint`}>{ hint }</div>
+          hint && <div className="nhsuk-hint" id={`${name}-hint`}><Markdown>{ hint }</Markdown></div>
         }
         <div className="nhsuk-radios">
           {

--- a/components/Snippet/index.js
+++ b/components/Snippet/index.js
@@ -1,8 +1,8 @@
-import ReactMarkdown from 'react-markdown';
 import classnames from 'classnames';
 import get from 'lodash/get';
 import Mustache from 'mustache';
 import { useContentContext } from '../../context/content';
+import Markdown from '../Markdown';
 
 const trim = (value) =>
   value
@@ -32,11 +32,11 @@ export default function Content({ children, inline, small, large, ...props }) {
   }
 
   return (
-    <ReactMarkdown
+    <Markdown
       includeElementIndex={true}
       components={{ p: conditionalInline }}
     >
       {source}
-    </ReactMarkdown>
+    </Markdown>
   );
 }

--- a/components/index.js
+++ b/components/index.js
@@ -3,6 +3,7 @@ export { default as BackLink } from './BackLink';
 export { default as CheckboxGroup } from './CheckboxGroup';
 export { default as Field } from './Field';
 export { default as Layout } from './Layout';
+export { default as Markdown } from './Markdown';
 export { default as RadioGroup } from './RadioGroup';
 export { default as Snippet } from './Snippet';
 


### PR DESCRIPTION
Where a link is an absolute URL beginning `http` then automatically open it in a new tab and suffix the text with `(opens in a new tab)`.

This means that links in content that is imported from the configuration spreadsheet can have this behaviour bound to them.